### PR TITLE
feat(sbom-collector): add configurable scratchDir for temporary file storage

### DIFF
--- a/kubernetes-agent/templates/_helpers.tpl
+++ b/kubernetes-agent/templates/_helpers.tpl
@@ -100,6 +100,26 @@ Set Go memory limit to 90% of container memory limit (min 100 MiB)
 {{- end -}}
 
 {{/*
+Validate sbomCollector.scratchDir configuration and fail early with a clear message.
+*/}}
+{{- define "sbom-collector.validateScratchDir" -}}
+{{- $validTypes := list "emptyDir" "hostPath" -}}
+{{- $scratchDir := .Values.sbomCollector.scratchDir | default dict -}}
+{{- $type := $scratchDir.type | default "emptyDir" -}}
+{{- if not (has $type $validTypes) -}}
+  {{- fail (printf "sbomCollector.scratchDir.type must be one of: %s" (join ", " $validTypes)) -}}
+{{- end -}}
+{{- if eq $type "hostPath" -}}
+  {{- if not $scratchDir.hostPath -}}
+    {{- fail "sbomCollector.scratchDir.hostPath must be set when type is 'hostPath'" -}}
+  {{- end -}}
+  {{- if eq $scratchDir.hostPath "/" -}}
+    {{- fail "sbomCollector.scratchDir.hostPath must not be the root filesystem '/'" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Get the secret name to use for the agent configuration.
 Uses externalSecret if provided, otherwise uses the chart name.
 */}}

--- a/kubernetes-agent/templates/sbom-collector/daemonset.yaml
+++ b/kubernetes-agent/templates/sbom-collector/daemonset.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.sbomCollector.enabled (eq .Values.sbomCollector.runAsDaemonSet true) }}
+{{- include "sbom-collector.validateScratchDir" . }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -116,10 +117,33 @@ spec:
             {{- end }}
       terminationGracePeriodSeconds: 30
       volumes:
+        {{- $scratchDir := .Values.sbomCollector.scratchDir | default dict }}
         - name: tmp
-          emptyDir: { }
+          {{- if eq ($scratchDir.type | default "emptyDir") "hostPath" }}
+          hostPath:
+            path: {{ $scratchDir.hostPath }}/tmp
+            type: DirectoryOrCreate
+          {{- else }}
+          emptyDir:
+            {{- if $scratchDir.sizeLimit }}
+            sizeLimit: {{ $scratchDir.sizeLimit }}
+            {{- else }}
+            {}
+            {{- end }}
+          {{- end }}
         - name: ecr-cache-config
-          emptyDir: { }
+          {{- if eq ($scratchDir.type | default "emptyDir") "hostPath" }}
+          hostPath:
+            path: {{ $scratchDir.hostPath }}/ecr
+            type: DirectoryOrCreate
+          {{- else }}
+          emptyDir:
+            {{- if $scratchDir.sizeLimit }}
+            sizeLimit: {{ $scratchDir.sizeLimit }}
+            {{- else }}
+            {}
+            {{- end }}
+          {{- end }}
         - name: docker-sock
           hostPath:
             path: /var/run/docker.sock

--- a/kubernetes-agent/templates/sbom-collector/deployment.yaml
+++ b/kubernetes-agent/templates/sbom-collector/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.sbomCollector.enabled (eq .Values.sbomCollector.runAsDaemonSet false) }}
+{{- include "sbom-collector.validateScratchDir" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -124,10 +125,33 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        {{- $scratchDir := .Values.sbomCollector.scratchDir | default dict }}
         - name: tmp
-          emptyDir: { }
+          {{- if eq ($scratchDir.type | default "emptyDir") "hostPath" }}
+          hostPath:
+            path: {{ $scratchDir.hostPath }}/tmp
+            type: DirectoryOrCreate
+          {{- else }}
+          emptyDir:
+            {{- if $scratchDir.sizeLimit }}
+            sizeLimit: {{ $scratchDir.sizeLimit }}
+            {{- else }}
+            {}
+            {{- end }}
+          {{- end }}
         - name: ecr-cache-config
-          emptyDir: { }
+          {{- if eq ($scratchDir.type | default "emptyDir") "hostPath" }}
+          hostPath:
+            path: {{ $scratchDir.hostPath }}/ecr
+            type: DirectoryOrCreate
+          {{- else }}
+          emptyDir:
+            {{- if $scratchDir.sizeLimit }}
+            sizeLimit: {{ $scratchDir.sizeLimit }}
+            {{- else }}
+            {}
+            {{- end }}
+          {{- end }}
         - name: docker-sock
           hostPath:
             path: /var/run/docker.sock

--- a/kubernetes-agent/values.yaml
+++ b/kubernetes-agent/values.yaml
@@ -100,6 +100,30 @@ sbomCollector:
     # Configure sbomCollector.secretsAccess.imagePullSecretNames for that.
     imagePullSecrets: []
 
+  # Scratch space configuration for temporary files used during SBOM generation.
+  # By default, emptyDir volumes are used for /tmp and /.ecr scratch space.
+  #
+  # type: emptyDir (default)
+  #   Kubernetes tracks ephemeral storage usage and can evict the pod if it exceeds limits.
+  #   Optionally set sizeLimit to cap disk usage per node.
+  #   scratchDir:
+  #     type: emptyDir
+  #     sizeLimit: 20Gi
+  #
+  # type: hostPath
+  #   Use a directory on a specific host partition. Useful on systems like Bottlerocket OS
+  #   where the default partition is small and a larger data partition should be used instead.
+  #   hostPath is required when using this type.
+  #   NOTE: hostPath bypasses Kubernetes ephemeral storage tracking — monitor disk usage
+  #   on the host path manually to avoid disk pressure on the node.
+  #   scratchDir:
+  #     type: hostPath
+  #     hostPath: /var/data/aikido-sbom
+  scratchDir:
+    type: emptyDir
+    hostPath: null
+    sizeLimit: null
+
   # Pull secret mount configuration
   # Mount a Docker config secret as a volume to authenticate with private registries.
   # This is useful for authenticating with registries like OpenShift's internal registry,


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added sbomCollector.scratchDir configuration supporting emptyDir or hostPath with optional sizeLimit and hostPath
* Updated daemonset and deployment templates to mount configured scratch volumes
* Added template include that validated scratchDir configuration before rendering


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99807524?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->