### PR TITLE
fix: Conditionally mount Docker and containerd sockets based on runAsUser value

### DIFF
--- a/kubernetes-agent/Chart.yaml
+++ b/kubernetes-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kubernetes-agent
 description: Install the Aikido Kubernetes Agent to secure and integrate your Kubernetes clusters with Aikido.
-version: 2.8.2
+version: 2.8.3
 appVersion: v1.13.0
 type: application

--- a/kubernetes-agent/templates/sbom-collector/daemonset.yaml
+++ b/kubernetes-agent/templates/sbom-collector/daemonset.yaml
@@ -100,12 +100,14 @@ spec:
               name: tmp
             - mountPath: /.ecr
               name: ecr-cache-config
+            {{- if eq (int .Values.sbomCollector.securityContext.runAsUser) 0 }}
             - name: docker-sock
               mountPath: /var/run/docker.sock
               readOnly: true
             - name: containerd-sock
               mountPath: /run/containerd/containerd.sock
               readOnly: true
+            {{- end }}
             {{- if .Values.sbomCollector.pullSecretMount.secretName }}
             - name: registry-pull-secret
               mountPath: /var/run/secrets/pull-secret
@@ -125,12 +127,14 @@ spec:
           emptyDir: { }
         - name: ecr-cache-config
           emptyDir: { }
+        {{- if eq (int .Values.sbomCollector.securityContext.runAsUser) 0 }}
         - name: docker-sock
           hostPath:
             path: /var/run/docker.sock
         - name: containerd-sock
           hostPath:
             path: /run/containerd/containerd.sock
+        {{- end }}
         {{- if .Values.sbomCollector.pullSecretMount.secretName }}
         - name: registry-pull-secret
           secret:

--- a/kubernetes-agent/templates/sbom-collector/deployment.yaml
+++ b/kubernetes-agent/templates/sbom-collector/deployment.yaml
@@ -97,12 +97,14 @@ spec:
               name: tmp
             - mountPath: /.ecr
               name: ecr-cache-config
+            {{- if eq (int .Values.sbomCollector.securityContext.runAsUser) 0 }}
             - name: docker-sock
               mountPath: /var/run/docker.sock
               readOnly: true
             - name: containerd-sock
               mountPath: /run/containerd/containerd.sock
               readOnly: true
+            {{- end }}
             {{- if .Values.sbomCollector.pullSecretMount.secretName }}
             - name: registry-pull-secret
               mountPath: /var/run/secrets/pull-secret
@@ -133,12 +135,14 @@ spec:
           emptyDir: { }
         - name: ecr-cache-config
           emptyDir: { }
+        {{- if eq (int .Values.sbomCollector.securityContext.runAsUser) 0 }}
         - name: docker-sock
           hostPath:
             path: /var/run/docker.sock
         - name: containerd-sock
           hostPath:
             path: /run/containerd/containerd.sock
+        {{- end }}
         {{- if .Values.sbomCollector.pullSecretMount.secretName }}
         - name: registry-pull-secret
           secret:


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Conditionally mounted Docker and containerd sockets when runAsUser was root
* Bumped chart version from 2.8.2 to 2.8.3 in Chart.yaml


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107980060?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->