### PR TITLE
fix: set AWS_ECR_CACHE_DIR

### DIFF
--- a/kubernetes-agent/Chart.yaml
+++ b/kubernetes-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kubernetes-agent
 description: Install the Aikido Kubernetes Agent to secure and integrate your Kubernetes clusters with Aikido.
-version: 2.9.0
+version: 2.9.1
 appVersion: v1.14.0
 type: application

--- a/kubernetes-agent/templates/sbom-collector/daemonset.yaml
+++ b/kubernetes-agent/templates/sbom-collector/daemonset.yaml
@@ -56,6 +56,8 @@ spec:
               value: http://{{ include "kubernetes-agent.fullname" . }}:{{ .Values.agent.service.port }}
             - name: GOMEMLIMIT
               value: "{{ include "kubernetes-sbom-collector.goMemLimit" . }}"
+            - name: AWS_ECR_CACHE_DIR
+              value: "/.ecr"
             - name: SECRETS_ACCESS_ENABLED
               value: "{{ .Values.sbomCollector.secretsAccess.enabled }}"
             - name: RUN_COLLECTOR_AS_DAEMONSET

--- a/kubernetes-agent/templates/sbom-collector/deployment.yaml
+++ b/kubernetes-agent/templates/sbom-collector/deployment.yaml
@@ -53,6 +53,8 @@ spec:
               value: http://{{ include "kubernetes-agent.fullname" . }}:{{ .Values.agent.service.port }}
             - name: GOMEMLIMIT
               value: "{{ include "kubernetes-sbom-collector.goMemLimit" . }}"
+            - name: AWS_ECR_CACHE_DIR
+              value: "/.ecr"
             - name: SECRETS_ACCESS_ENABLED
               value: "{{ .Values.sbomCollector.secretsAccess.enabled }}"
             - name: RUN_COLLECTOR_AS_DAEMONSET


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added AWS_ECR_CACHE_DIR environment variable to sbom-collector containers in deployment and daemonset manifests
* Bumped kubernetes-agent chart version from 2.9.0 to 2.9.1


<sup>[More info](https://app.aikido.dev/featurebranch/scan/113604378?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->