### PR TITLE
broker client 1.0.40

### DIFF
--- a/broker-client/Chart.yaml
+++ b/broker-client/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: broker-client
 description: Aikido Broker Client - Securely forward requests to internal resources
 type: application
-version: 1.0.20
-appVersion: "1.0.35"
+version: 1.0.21
+appVersion: "1.0.40"
 keywords:
   - security
   - broker

--- a/broker-client/values.yaml
+++ b/broker-client/values.yaml
@@ -77,7 +77,7 @@ config:
 image:
   repository: aikidosecurity/broker-client
   pullPolicy: IfNotPresent
-  tag: '1.0.35' # Overrides the image tag (default is the appVersion from Chart.yaml)
+  tag: '1.0.40' # Overrides the image tag (default is the appVersion from Chart.yaml)
 
 imagePullSecrets: []
 nameOverride: ''


### PR DESCRIPTION
- fixed streams lacking content length header getting interrupted
- fix CVEs

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Bumped Helm chart version from 1.0.20 to 1.0.21.
* Updated application appVersion and Docker image tag to 1.0.40.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/118427909?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->