### PR TITLE
feat: broker client support referencing an existing secret for CLIENT_SECRET

### DIFF
--- a/broker-client/Chart.yaml
+++ b/broker-client/Chart.yaml
@@ -3,7 +3,7 @@ name: broker-client
 description: Aikido Broker Client - Securely forward requests to internal resources
 type: application
 version: 1.0.22
-appVersion: "1.0.40"
+appVersion: "1.0.46"
 keywords:
   - security
   - broker

--- a/broker-client/Chart.yaml
+++ b/broker-client/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: broker-client
 description: Aikido Broker Client - Securely forward requests to internal resources
 type: application
-version: 1.0.21
+version: 1.0.22
 appVersion: "1.0.40"
 keywords:
   - security

--- a/broker-client/templates/deployment.yaml
+++ b/broker-client/templates/deployment.yaml
@@ -39,6 +39,14 @@ spec:
         envFrom:
         - secretRef:
             name: {{ include "broker-client.fullname" . }}
+        {{- if .Values.config.existingSecretName }}
+        env:
+        - name: CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.config.existingSecretName }}
+              key: {{ .Values.config.existingSecretKey | default "CLIENT_SECRET" }}
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:

--- a/broker-client/templates/deployment.yaml
+++ b/broker-client/templates/deployment.yaml
@@ -13,10 +13,11 @@ spec:
       {{- include "broker-client.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "broker-client.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}

--- a/broker-client/templates/secret.yaml
+++ b/broker-client/templates/secret.yaml
@@ -6,7 +6,9 @@ metadata:
     {{- include "broker-client.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  CLIENT_SECRET: {{ .Values.config.clientSecret | required "config.clientSecret is required" | quote }}
+  {{- if not .Values.config.existingSecretName }}
+  CLIENT_SECRET: {{ .Values.config.clientSecret | required "config.clientSecret is required when config.existingSecretName is not set" | quote }}
+  {{- end }}
   ALLOWED_INTERNAL_SUBNETS: {{ .Values.config.allowedInternalSubnets | quote }}
   {{- if .Values.config.dnsServers }}
   DNS_SERVERS: {{ .Values.config.dnsServers | quote }}

--- a/broker-client/templates/secret.yaml
+++ b/broker-client/templates/secret.yaml
@@ -46,6 +46,9 @@ stringData:
   {{- if .Values.config.noProxy }}
   NO_PROXY: {{ .Values.config.noProxy | quote }}
   {{- end }}
+  {{- if .Values.config.debugRequests }}
+  DEBUG_REQUESTS: {{ .Values.config.debugRequests | quote }}
+  {{- end }}
 {{- if .Values.config.customCaBundleContent }}
 ---
 apiVersion: v1

--- a/broker-client/values.yaml
+++ b/broker-client/values.yaml
@@ -4,8 +4,16 @@
 
 # Broker client configuration
 config:
-  # REQUIRED: Your broker client secret from Aikido
+  # REQUIRED: Your broker client secret from Aikido.
+  # Ignored when existingSecretName is set.
   clientSecret: ''
+
+  # Optional: Name of an existing Kubernetes Secret that holds the clientSecret value.
+  # Use this with GitOps tools (e.g. ArgoCD + SOPS) to avoid committing the secret to git.
+  # When set, config.clientSecret is ignored.
+  existingSecretName: ''
+  # Key inside the existing secret that holds the client secret value.
+  existingSecretKey: 'CLIENT_SECRET'
 
   # REQUIRED: Allowed internal subnets (comma-separated CIDR blocks)
   # Example: "192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,127.0.0.0/8"

--- a/broker-client/values.yaml
+++ b/broker-client/values.yaml
@@ -85,7 +85,7 @@ config:
 image:
   repository: aikidosecurity/broker-client
   pullPolicy: IfNotPresent
-  tag: '1.0.40' # Overrides the image tag (default is the appVersion from Chart.yaml)
+  tag: '1.0.46' # Overrides the image tag (default is the appVersion from Chart.yaml)
 
 imagePullSecrets: []
 nameOverride: ''

--- a/broker-client/values.yaml
+++ b/broker-client/values.yaml
@@ -55,6 +55,10 @@ config:
   # Set to "true" to force polling connection
   forcePolling: ''
 
+  # Optional: Log all proxied requests for debugging
+  # Set to "1" to enable request debug logging
+  debugRequests: ''
+
   # Optional: No proxy configuration
   # Comma-separated list of hosts/domains that should bypass the proxy
   # Example: "localhost,127.0.0.1,.company.local"


### PR DESCRIPTION
also bumped client version to 1.0.46 which adds request debug env var

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Supported referencing an existing Kubernetes Secret for CLIENT_SECRET.
* Added debugRequests config and DEBUG_REQUESTS environment variable support.
* Bumped Docker image tag and Chart appVersion/version to 1.0.46.
* Added checksum pod annotation to include secret checksum for redeploy.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/129376282?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->